### PR TITLE
[#8] address history crud 구현

### DIFF
--- a/team1-api/build.gradle
+++ b/team1-api/build.gradle
@@ -15,4 +15,6 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'
 
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/address/presentation/AddressController.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/address/presentation/AddressController.java
@@ -1,7 +1,6 @@
 package goorm.deepdive.team1.api.address.presentation;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -71,7 +70,6 @@ public interface AddressController {
 			- Description : 이 API는 주소 데이터를 삭제할 수 있습니다.
 		""")
 	@ApiResponse(responseCode = "204")
-	@PatchMapping("/{id}")
 	ResponseEntity<Void> delete(
 		@Parameter(description = "삭제할 주소의 ID", example = "1")
 		@PathVariable Long id

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -11,10 +11,13 @@ import goorm.deepdive.team1.api.user.presentation.resonse.UserListResponse;
 import goorm.deepdive.team1.api.user.presentation.resonse.UserPersistResponse;
 import goorm.deepdive.team1.api.user.presentation.resonse.UserResponse;
 import goorm.deepdive.team1.domain.address.application.AddressCommandService;
+import goorm.deepdive.team1.domain.address.application.AddressQueryService;
+import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.addresshistory.application.AddressHistoryCommandService;
 import goorm.deepdive.team1.domain.user.application.UserCommandService;
 import goorm.deepdive.team1.domain.user.application.UserQueryService;
 import goorm.deepdive.team1.domain.user.domain.User;
+import goorm.deepdive.team1.domain.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -24,16 +27,21 @@ public class UserFacade {
 	private final UserCommandService userCommandService;
 	private final AddressHistoryCommandService addressHistoryCommandService;
 	private final AddressCommandService addressCommandService;
+	private final AddressQueryService addressQueryService;
 
 	@Transactional
 	public UserPersistResponse create(UserCreateRequest request) {
 		User user = userCommandService.create(request.name(), request.email(), request.phoneNumber());
-		/* todo : 유저 생성 시 주소 같이 저장 로직 구현
-		Address address = addressSearchService(request.address());
-		addressCommandService.create(address);
-
+		Address address = null;
+		try {
+			address = addressQueryService.getByAddress(request.address());
+		} catch (UserNotFoundException e) {
+			// todo : 카카오 api를 이용하여 주소 데이터를 가져와서 저장
+			// address = addressCommandService.create();
+			// addressCommandService.save(address);
+		}
 		addressHistoryCommandService.create(user, address);
-		*/
+
 		return UserPersistResponse.from(user);
 	}
 

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -3,12 +3,15 @@ package goorm.deepdive.team1.api.user.application;
 import java.util.List;
 
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import goorm.deepdive.team1.api.user.presentation.request.UserCreateRequest;
 import goorm.deepdive.team1.api.user.presentation.request.UserUpdateRequest;
 import goorm.deepdive.team1.api.user.presentation.resonse.UserListResponse;
 import goorm.deepdive.team1.api.user.presentation.resonse.UserPersistResponse;
 import goorm.deepdive.team1.api.user.presentation.resonse.UserResponse;
+import goorm.deepdive.team1.domain.address.application.AddressCommandService;
+import goorm.deepdive.team1.domain.addresshistory.application.AddressHistoryCommandService;
 import goorm.deepdive.team1.domain.user.application.UserCommandService;
 import goorm.deepdive.team1.domain.user.application.UserQueryService;
 import goorm.deepdive.team1.domain.user.domain.User;
@@ -19,9 +22,18 @@ import lombok.RequiredArgsConstructor;
 public class UserFacade {
 	private final UserQueryService userQueryService;
 	private final UserCommandService userCommandService;
+	private final AddressHistoryCommandService addressHistoryCommandService;
+	private final AddressCommandService addressCommandService;
 
+	@Transactional
 	public UserPersistResponse create(UserCreateRequest request) {
 		User user = userCommandService.create(request.name(), request.email(), request.phoneNumber());
+		/* todo : 유저 생성 시 주소 같이 저장 로직 구현
+		Address address = addressSearchService(request.address());
+		addressCommandService.create(address);
+
+		addressHistoryCommandService.create(user, address);
+		*/
 		return UserPersistResponse.from(user);
 	}
 
@@ -41,5 +53,10 @@ public class UserFacade {
 
 	public void delete(Long id) {
 		userCommandService.delete(id);
+	}
+
+	public UserListResponse searchUsersByAddressKeyword(String keyword) {
+		List<User> userList = userQueryService.getUsersByAddressKeyword(keyword);
+		return UserListResponse.from(userList);
 	}
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/presentation/UserController.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/presentation/UserController.java
@@ -1,9 +1,9 @@
 package goorm.deepdive.team1.api.user.presentation;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import goorm.deepdive.team1.api.user.presentation.request.UserCreateRequest;
 import goorm.deepdive.team1.api.user.presentation.request.UserUpdateRequest;
@@ -71,9 +71,18 @@ public interface UserController {
 			- Description : 이 API는 유저 데이터를 삭제할 수 있습니다.
 		""")
 	@ApiResponse(responseCode = "204")
-	@PatchMapping("/{id}")
 	ResponseEntity<Void> delete(
 		@Parameter(description = "삭제할 사용자의 ID", example = "1")
 		@PathVariable Long id
+	);
+
+	@Operation(summary = "주소 기반 유저 목록 검색 API", description = """
+			- Description : 이 API는 해당 키워드를 포함한 주소를 가지고 있는 유저 목록을 조회할 수 있습니다.
+		""")
+	@ApiResponse(responseCode = "200")
+	ResponseEntity<UserListResponse> searchUsersByAddressKeyword(
+		@Parameter(description = "검색할 주소 키워드", example = "강남")
+		@RequestParam(required = false)
+		String keyword
 	);
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/presentation/UserControllerImpl.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/presentation/UserControllerImpl.java
@@ -58,4 +58,11 @@ public class UserControllerImpl implements UserController{
 		userFacade.delete(id);
 		return ResponseEntity.noContent().build();
 	}
+
+	@Override
+	@GetMapping("/search")
+	public ResponseEntity<UserListResponse> searchUsersByAddressKeyword(String keyword) {
+		UserListResponse response = userFacade.searchUsersByAddressKeyword(keyword);
+		return ResponseEntity.ok(response);
+	}
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/presentation/request/UserCreateRequest.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/presentation/request/UserCreateRequest.java
@@ -16,6 +16,10 @@ public record UserCreateRequest(
 
 	@Schema(description = "휴대폰 번호", example = "01012345678", requiredMode = REQUIRED)
 	@NotBlank
-	String phoneNumber
+	String phoneNumber,
+
+	@Schema(description = "주소", example = "창훈로 52번길 22", requiredMode = REQUIRED)
+	@NotBlank
+	String address
 ) {
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/address/application/AddressCommandService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/address/application/AddressCommandService.java
@@ -19,6 +19,10 @@ public class AddressCommandService {
 		return addressRepository.save(address);
 	}
 
+	public Address save(Address address) {
+		return addressRepository.save(address);
+	}
+
 	public void update(Long id, double x, double y, String regionAddress, String roadAddress) {
 		Address address = getAddress(id);
 

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/address/application/AddressQueryService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/address/application/AddressQueryService.java
@@ -24,4 +24,10 @@ public class AddressQueryService {
 	public List<Address> getAllByDeletedAtIsNull() {
 		return addressRepository.findAllByDeletedAtIsNull();
 	}
+
+	public Address getByAddress(String address) {
+		return addressRepository.findByRegionAddressOrRoadAddressAndDeletedAtIsNull(address)
+			.orElseThrow(AddressNotFoundException::new);
+	}
+
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/address/infrastructure/AddressRepository.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/address/infrastructure/AddressRepository.java
@@ -13,4 +13,6 @@ public interface AddressRepository {
 	List<Address> findAllByDeletedAtIsNull();
 
 	void delete(Address address);
+
+	Optional<Address> findByRegionAddressOrRoadAddressAndDeletedAtIsNull(String address);
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/application/AddressHistoryCommandService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/application/AddressHistoryCommandService.java
@@ -1,0 +1,33 @@
+package goorm.deepdive.team1.domain.addresshistory.application;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import goorm.deepdive.team1.domain.address.domain.Address;
+import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+import goorm.deepdive.team1.domain.addresshistory.exception.AddressHistoryNotFoundException;
+import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryRepository;
+import goorm.deepdive.team1.domain.user.domain.User;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AddressHistoryCommandService {
+	private final AddressHistoryRepository addressHistoryRepository;
+
+	public AddressHistory create(User user, Address address) {
+		AddressHistory addressHistory = AddressHistory.create(user, address);
+		return addressHistoryRepository.save(addressHistory);
+	}
+
+	public void delete(Long id) {
+		AddressHistory addressHistory = getById(id);
+		addressHistoryRepository.delete(addressHistory);
+	}
+
+	private AddressHistory getById(Long id) {
+		return addressHistoryRepository.findByIdAndDeletedAtIsNull(id)
+			.orElseThrow(AddressHistoryNotFoundException::new);
+	}
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/application/AddressHistoryQueryService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/application/AddressHistoryQueryService.java
@@ -1,0 +1,25 @@
+package goorm.deepdive.team1.domain.addresshistory.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+import goorm.deepdive.team1.domain.addresshistory.exception.AddressHistoryNotFoundException;
+import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AddressHistoryQueryService {
+	private final AddressHistoryRepository addressHistoryRepository;
+
+	public AddressHistory getById(Long id) {
+		return addressHistoryRepository.findByIdAndDeletedAtIsNull(id)
+			.orElseThrow(AddressHistoryNotFoundException::new);
+	}
+
+	public List<AddressHistory> getAllByDeletedAtIsNull() {
+		return addressHistoryRepository.findAllByDeletedAtIsNull();
+	}
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/domain/AddressHistory.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/domain/AddressHistory.java
@@ -4,6 +4,7 @@ import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
+import goorm.deepdive.team1.domain.BaseTimeEntity;
 import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.user.domain.User;
 import jakarta.persistence.Entity;
@@ -21,7 +22,7 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PROTECTED)
-public class AddressHistory {
+public class AddressHistory extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
@@ -31,10 +32,13 @@ public class AddressHistory {
 	private User user;
 
 	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "old_addr_id", nullable = false)
-	private Address oldAddress;
+	@JoinColumn(name = "address_id", nullable = false)
+	private Address address;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "new_addr_id", nullable = false)
-	private Address newAddress;
+	public static AddressHistory create(User user, Address address) {
+		return AddressHistory.builder()
+			.user(user)
+			.address(address)
+			.build();
+	}
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/exception/AddressHistoryDomainExceptionCode.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/exception/AddressHistoryDomainExceptionCode.java
@@ -1,0 +1,24 @@
+package goorm.deepdive.team1.domain.addresshistory.exception;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+import goorm.deepdive.team1.common.exception.ExceptionCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AddressHistoryDomainExceptionCode implements ExceptionCode {
+	ADDRESS_HISTORY_NOT_FOUND(NOT_FOUND, "해당 주소 이력을 찾을 수 없습니다."),
+	;
+
+	private final HttpStatus status;
+	private final String message;
+
+	@Override
+	public String getCode() {
+		return this.name();
+	}
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/exception/AddressHistoryNotFoundException.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/exception/AddressHistoryNotFoundException.java
@@ -1,0 +1,11 @@
+package goorm.deepdive.team1.domain.addresshistory.exception;
+
+import static goorm.deepdive.team1.domain.addresshistory.exception.AddressHistoryDomainExceptionCode.ADDRESS_HISTORY_NOT_FOUND;
+
+import goorm.deepdive.team1.common.exception.CustomException;
+
+public class AddressHistoryNotFoundException extends CustomException {
+	public AddressHistoryNotFoundException() {
+		super(ADDRESS_HISTORY_NOT_FOUND);
+	}
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/infrastructure/AddressHistoryInterface.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/infrastructure/AddressHistoryInterface.java
@@ -1,4 +1,0 @@
-package goorm.deepdive.team1.domain.addresshistory.infrastructure;
-
-public class AddressHistoryInterface {
-}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/infrastructure/AddressHistoryRepository.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/infrastructure/AddressHistoryRepository.java
@@ -1,0 +1,16 @@
+package goorm.deepdive.team1.domain.addresshistory.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+
+import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+
+public interface AddressHistoryRepository {
+	AddressHistory save(AddressHistory addressHistory);
+
+	Optional<AddressHistory> findByIdAndDeletedAtIsNull(Long id);
+
+	List<AddressHistory> findAllByDeletedAtIsNull();
+
+	void delete(AddressHistory addressHistory);
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/application/UserQueryService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/application/UserQueryService.java
@@ -24,4 +24,8 @@ public class UserQueryService {
 	public List<User> getAllByDeletedAtIsNull() {
 		return userRepository.findAllByDeletedAtIsNull();
 	}
+
+	public List<User> getUsersByAddressKeyword(String keyword) {
+		return userRepository.findUsersByAddressKeyword(keyword);
+	}
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/infrastructure/UserRepository.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/infrastructure/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository {
 	void deleteById(Long id);
 
 	boolean existsById(Long id);
+
+	List<User> findUsersByAddressKeyword(String keyword);
 }

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/impl/AddressHistoryRepositoryImpl.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/impl/AddressHistoryRepositoryImpl.java
@@ -1,0 +1,37 @@
+package goorm.deepdive.team1.infra.config.repository.impl;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryRepository;
+import goorm.deepdive.team1.infra.config.repository.jpa.JpaAddressHistoryRepository;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AddressHistoryRepositoryImpl implements AddressHistoryRepository {
+	private final JpaAddressHistoryRepository jpaAddressHistoryRepository;
+
+	@Override
+	public AddressHistory save(AddressHistory addressHistory) {
+		return jpaAddressHistoryRepository.save(addressHistory);
+	}
+
+	@Override
+	public Optional<AddressHistory> findByIdAndDeletedAtIsNull(Long id) {
+		return jpaAddressHistoryRepository.findByIdAndDeletedAtIsNull(id);
+	}
+
+	@Override
+	public List<AddressHistory> findAllByDeletedAtIsNull() {
+		return jpaAddressHistoryRepository.findAllByDeletedAtIsNull();
+	}
+
+	@Override
+	public void delete(AddressHistory addressHistory) {
+		jpaAddressHistoryRepository.delete(addressHistory);
+	}
+}

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/impl/AddressRepositoryImpl.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/impl/AddressRepositoryImpl.java
@@ -34,4 +34,9 @@ public class AddressRepositoryImpl implements AddressRepository {
 	public void delete(Address address) {
 		jpaAddressRepository.delete(address);
 	}
+
+	@Override
+	public Optional<Address> findByRegionAddressOrRoadAddressAndDeletedAtIsNull(String address) {
+		return jpaAddressRepository.findByRegionAddressOrRoadAddressAndDeletedAtIsNull(address, address);
+	}
 }

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/impl/UserRepositoryImpl.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/impl/UserRepositoryImpl.java
@@ -39,4 +39,9 @@ public class UserRepositoryImpl implements UserRepository {
 	public boolean existsById(Long id) {
 		return jpaUserRepository.existsById(id);
 	}
+
+	@Override
+	public List<User> findUsersByAddressKeyword(String keyword) {
+		return jpaUserRepository.findUsersByAddressKeyword(keyword);
+	}
 }

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/jpa/JpaAddressHistoryRepository.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/jpa/JpaAddressHistoryRepository.java
@@ -1,0 +1,14 @@
+package goorm.deepdive.team1.infra.config.repository.jpa;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+
+public interface JpaAddressHistoryRepository extends JpaRepository<AddressHistory, Long> {
+	List<AddressHistory> findAllByDeletedAtIsNull();
+
+	Optional<AddressHistory> findByIdAndDeletedAtIsNull(Long id);
+}

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/jpa/JpaAddressRepository.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/jpa/JpaAddressRepository.java
@@ -11,4 +11,6 @@ public interface JpaAddressRepository extends JpaRepository<Address, Long> {
 	List<Address> findAllByDeletedAtIsNull();
 
 	Optional<Address> findByIdAndDeletedAtIsNull(Long id);
+
+	Optional<Address> findByRegionAddressOrRoadAddressAndDeletedAtIsNull(String region, String road);
 }

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/jpa/JpaUserRepository.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/config/repository/jpa/JpaUserRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import goorm.deepdive.team1.domain.user.domain.User;
 
@@ -11,4 +13,24 @@ public interface JpaUserRepository extends JpaRepository<User, Long> {
 	List<User> findAllByDeletedAtIsNull();
 
 	Optional<User> findByIdAndDeletedAtIsNull(Long id);
+
+	@Query("""
+        SELECT u
+        FROM User u
+        WHERE u.deletedAt IS NULL
+         	AND u.id IN (
+            	SELECT ah.user.id
+            	FROM AddressHistory ah
+            	WHERE ah.id IN (
+                	SELECT MAX(subAh.id)
+                	FROM AddressHistory subAh
+                	GROUP BY subAh.user.id
+            	)
+            	AND (
+                	LOWER(ah.address.regionAddress) LIKE LOWER(CONCAT('%', :keyword, '%')) 
+                	OR LOWER(ah.address.roadAddress) LIKE LOWER(CONCAT('%', :keyword, '%'))
+            	)
+        	)
+    """)
+	List<User> findUsersByAddressKeyword(@Param("keyword") String keyword);
 }


### PR DESCRIPTION
## Summary

>- close #8 

**address history crud 구현**

## Tasks

- AddressHistory infra, domain layer 구현
- 주소 기반 유저 목록 검색 기능 구현

## To Reviewer
api를 개발하지 않은 이유는 address history는 기록을 저장하는 용도다 보니 api는 User 도메인 에서만 개발하면 된다고 생각되어 개발하지 않았습니다. 그리고 테스트는 추후에 더미 데이터 생성 기능을 구현 후 진행 할 예정입니다.

그리고 동시 카카오맵 api를 이용하여 주소 저장하는 부분은 UserFacade에 주석처리 했습니다 참고하셔서 작업하시면 될 것 같습니다 !

혹시 부족한 부분있으면 코멘트로 남겨주심 감사하겠습니다😁