### PR TITLE
[#32] 관리자 삭제,비번 번경api추가 ,헬스체크 경로 추가

### DIFF
--- a/team1-api/build.gradle
+++ b/team1-api/build.gradle
@@ -25,4 +25,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    //Health Check
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/application/AdminFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/application/AdminFacade.java
@@ -1,6 +1,7 @@
 package goorm.deepdive.team1.api.admin.application;
 
 import goorm.deepdive.team1.api.admin.presentation.request.AdminRegisterRequest;
+import goorm.deepdive.team1.api.admin.presentation.request.AdminPasswordUpdateRequest;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminRegisterResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminReissueResponse;
 import goorm.deepdive.team1.api.jwt.CookieUtil;
@@ -10,7 +11,6 @@ import goorm.deepdive.team1.api.jwt.exception.JwtExpiredException;
 import goorm.deepdive.team1.api.jwt.exception.JwtRedisStorageException;
 import goorm.deepdive.team1.common.exception.AdminExceptionCode;
 import goorm.deepdive.team1.common.exception.CustomException;
-import goorm.deepdive.team1.common.exception.JwtExceptionCode;
 import goorm.deepdive.team1.domain.admin.application.AdminCommandService;
 import goorm.deepdive.team1.domain.admin.application.AdminQueryService;
 import goorm.deepdive.team1.domain.admin.domain.Admin;
@@ -30,6 +30,7 @@ public class AdminFacade {
     private final TokenRepository tokenRepository;
 
     public AdminRegisterResponse register(AdminRegisterRequest request) {
+        // 해당 부분 예외처리 수정 필요
         if (adminQueryService.existsByEmail(request.email())) {
             throw new CustomException(AdminExceptionCode.ALREADY_REGISTERED);
         }
@@ -37,8 +38,6 @@ public class AdminFacade {
         Admin admin = adminCommandService.register(request.email(), request.password(), request.role());
         return new AdminRegisterResponse(admin.getId(), admin.getEmail());
     }
-
-
 
     public AdminReissueResponse reissueToken(HttpServletRequest request, HttpServletResponse response) {
         // 쿠키에서 리프레시 토큰 가져오기
@@ -93,4 +92,13 @@ public class AdminFacade {
         CookieUtil.clearAuthCookie(response, "Refresh-Token"); // 쿠키 삭제
 
     }
+
+    public void deleteAdmin(Long adminId) {
+        adminCommandService.deleteAdmin(adminId);
+    }
+
+    public void updatePassword(Long adminId, AdminPasswordUpdateRequest request) {
+        adminCommandService.updatePassword(adminId, request.oldPassword(), request.newPassword());
+    }
+
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminController.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 
 import goorm.deepdive.team1.api.admin.presentation.request.AdminRegisterRequest;
+import goorm.deepdive.team1.api.admin.presentation.request.AdminPasswordUpdateRequest;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminLoginRequest;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminRegisterResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminReissueResponse;
@@ -57,13 +58,29 @@ public interface AdminController {
     @PostMapping("/reissue")
     ResponseEntity<AdminReissueResponse> reissueToken(HttpServletRequest request, HttpServletResponse response);
 
-
-
-
     @Operation(summary = "관리자 로그아웃 API", description = """
             - Description : 로그아웃을 수행하며, 리프레시 토큰을 삭제하고 세션을 종료합니다.
         """)
     @ApiResponse(responseCode = "200", description = "로그아웃 성공")
     @PostMapping("/logout")
     ResponseEntity<Void> logout(HttpServletRequest request, HttpServletResponse response);
+
+    @Operation(summary = "관리자 삭제 API", description = """
+            - Description : 특정 관리자를 삭제하는 API입니다.
+        """)
+    @ApiResponse(responseCode = "204", description = "관리자 삭제 성공")
+    @ApiResponse(responseCode = "404", description = "관리자를 찾을 수 없음")
+    @DeleteMapping("/{adminId}")
+    ResponseEntity<Void> deleteAdmin(@PathVariable Long adminId);
+
+    @Operation(summary = "관리자 비밀번호 변경 API", description = """
+            - Description : 기존 비밀번호를 검증한 후 새 비밀번호로 변경하는 API입니다.
+        """)
+    @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공")
+    @ApiResponse(responseCode = "401", description = "기존 비밀번호 불일치")
+    @ApiResponse(responseCode = "404", description = "관리자를 찾을 수 없음")
+    @PatchMapping("/{adminId}/password")
+    ResponseEntity<Void> updatePassword(
+            @PathVariable Long adminId,
+            @RequestBody AdminPasswordUpdateRequest request);
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminControllerImpl.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminControllerImpl.java
@@ -3,7 +3,7 @@ package goorm.deepdive.team1.api.admin.presentation;
 import goorm.deepdive.team1.api.admin.application.AdminFacade;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminLoginRequest;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminRegisterRequest;
-import goorm.deepdive.team1.api.admin.presentation.response.AdminLoginResponse;
+import goorm.deepdive.team1.api.admin.presentation.request.AdminPasswordUpdateRequest;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminRegisterResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminReissueResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -51,6 +51,19 @@ public class AdminControllerImpl implements AdminController{
         return ResponseEntity.ok().build();
     }
 
+    @Override
+    @DeleteMapping("/{adminId}")
+    public ResponseEntity<Void> deleteAdmin(@PathVariable Long adminId) {
+        adminFacade.deleteAdmin(adminId);
+        return ResponseEntity.noContent().build(); // 204 No Content 반환
+    }
 
-
+    @Override
+    @PatchMapping("/{adminId}/password")
+    public ResponseEntity<Void> updatePassword(
+            @PathVariable Long adminId,
+            @RequestBody AdminPasswordUpdateRequest request) {
+        adminFacade.updatePassword(adminId, request);
+        return ResponseEntity.ok().build(); // 200 OK 반환
+    }
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/request/AdminPasswordUpdateRequest.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/request/AdminPasswordUpdateRequest.java
@@ -1,0 +1,7 @@
+package goorm.deepdive.team1.api.admin.presentation.request;
+
+public record AdminPasswordUpdateRequest(
+        String oldPassword,
+        String newPassword
+){
+}

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/jwt/JwtFilter.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/jwt/JwtFilter.java
@@ -80,7 +80,8 @@ public class JwtFilter extends OncePerRequestFilter {
                 || uri.contains("v3/api-docs") || uri.contains("webjars")
                 || uri.contains("/reissue")
                 || uri.contains("/register") // 회원가입 엔드포인트 추가
-                || uri.contains("/logout");
+                || uri.contains("/logout")
+                || uri.contains("/actuator/health");
     }
 
 

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/security/SecurityConfig.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/security/SecurityConfig.java
@@ -91,7 +91,7 @@ public class SecurityConfig implements Team1Config {
         return request -> {
             CorsConfiguration config = new CorsConfiguration();
             config.setAllowedHeaders(Collections.singletonList("*"));
-            config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
+            config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE","PATCH"));
             config.setAllowedOriginPatterns(Arrays.asList("*"));
             config.setAllowCredentials(true);
             return config;

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/application/AdminCommandService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/application/AdminCommandService.java
@@ -4,6 +4,8 @@ import goorm.deepdive.team1.domain.admin.domain.Admin;
 import goorm.deepdive.team1.domain.admin.domain.Role;
 import goorm.deepdive.team1.domain.admin.infrastructure.AdminRepository;
 import goorm.deepdive.team1.domain.admin.security.PasswordEncryptor;
+import goorm.deepdive.team1.domain.admin.exception.AdminPasswordMismatchException;
+import goorm.deepdive.team1.domain.admin.exception.AdminNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +25,29 @@ public class AdminCommandService {
                 .role(Role.valueOf(role))
                 .build();
         return adminRepository.save(admin);
+    }
+
+    @Transactional
+    public void deleteAdmin(Long adminId) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(AdminNotFoundException::new);
+
+        adminRepository.delete(admin);
+    }
+
+    @Transactional
+    public void updatePassword(Long adminId, String oldPassword, String newPassword) {
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(AdminNotFoundException::new);
+
+        // 기존 비밀번호 검증
+        if (!passwordEncryptor.matches(oldPassword, admin.getPassword())) {
+            throw new AdminPasswordMismatchException();
+        }
+
+        // 새 비밀번호 암호화 후 저장
+        admin.updatePassword(passwordEncryptor.encode(newPassword));
+        adminRepository.save(admin);
     }
 
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/domain/Admin.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/domain/Admin.java
@@ -33,4 +33,9 @@ public class Admin {
 	@Enumerated(STRING)
 	@Column(nullable = false)
 	private Role role;
+
+	public void updatePassword(String password) {
+		this.password = password;
+	}
+
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/exception/AdminPasswordMismatchException.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/exception/AdminPasswordMismatchException.java
@@ -4,8 +4,8 @@ import goorm.deepdive.team1.common.exception.CustomException;
 
 import static goorm.deepdive.team1.domain.admin.exception.AdminDomainExceptionCode.PASSWORD_MISMATCH;
 
-public class PasswordMismatchException extends CustomException {
-    public PasswordMismatchException() {
+public class AdminPasswordMismatchException extends CustomException {
+    public AdminPasswordMismatchException() {
         super(PASSWORD_MISMATCH);
     }
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/infrastructure/AdminRepository.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/infrastructure/AdminRepository.java
@@ -5,6 +5,12 @@ import java.util.Optional;
 
 public interface AdminRepository {
     Admin save(Admin admin);
+
     Optional<Admin> findByEmail(String email);
+
     boolean existsByEmail(String email);
+
+    Optional<Admin> findById(Long id);
+
+    void delete(Admin admin);
 }

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/repository/impl/AdminRepositoryImpl.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/repository/impl/AdminRepositoryImpl.java
@@ -27,4 +27,14 @@ public class AdminRepositoryImpl implements AdminRepository {
     public boolean existsByEmail(String email) {
         return jpaAdminRepository.existsByEmail(email);
     }
+
+    @Override
+    public Optional<Admin> findById(Long id) {
+        return jpaAdminRepository.findById(id);
+    }
+
+    @Override
+    public void delete(Admin admin) {
+        jpaAdminRepository.delete(admin);
+    }
 }


### PR DESCRIPTION
## Summary

>- close #32 

## Tasks

관리자  삭제,비밀번호 변경 api 추가 
헬스 체크 경로를 위한 api 모듈의  build 파일에 actuator 추가 

## Screenshot
**관리자 비밀번호 변경 api 테스트**
![스크린샷 2025-02-14 오후 3 56 36](https://github.com/user-attachments/assets/0
![스크린샷 2025-02-14 오후 3 56 42](https://github.com/user-attachments/assets/b03af977-3af5-4945-bbcd-26ca95a30e1d)
22582a3-22d2-4f5d-8caf-6f94e8a7d76d)


**관리자 삭제 api 테스트  -) 204 응답확인**
![스크린샷 2025-02-14 오후 3 57 20](https://github.com/user-attachments/assets/299fc609-d7bc-46f8-9b6d-b88b23249f2a)

** dependencies 추가 ** 
implementation 'org.springframework.boot:spring-boot-starter-actuator' 을 추가하면 아래 사진처럼 헬스체크 경로를 자동으로 만들어줍니다
추가로 후에 프로메테우스에서 해당 의존성을 사용하므로 추가했습니다  
![스크린샷 2025-02-14 오후 3 54 36](https://github.com/user-attachments/assets/916c91a5-1fc0-48cf-84c1-1bc62a9903fc)


< 테스트 코드는 작성은 안되어 있습니다  -  추가 에정 > 
