### PR TITLE
[#44] 관리자 이메일 검색 api 추가 

### DIFF
--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/application/AdminFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/application/AdminFacade.java
@@ -120,4 +120,8 @@ public class AdminFacade {
         return adminQueryService.getAdminsByPage(page, size);
     }
 
+    public Admin getAdminByEmail(String email) {
+        return adminQueryService.getAdminByEmail(email);
+    }
+
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminController.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminController.java
@@ -1,15 +1,12 @@
 package goorm.deepdive.team1.api.admin.presentation;
 
-import goorm.deepdive.team1.api.admin.presentation.response.AdminListResponse;
+import goorm.deepdive.team1.api.admin.presentation.response.*;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 
 import goorm.deepdive.team1.api.admin.presentation.request.AdminRegisterRequest;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminPasswordUpdateRequest;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminLoginRequest;
-import goorm.deepdive.team1.api.admin.presentation.response.AdminRegisterResponse;
-import goorm.deepdive.team1.api.admin.presentation.response.AdminReissueResponse;
-import goorm.deepdive.team1.api.admin.presentation.response.AdminLoginResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -106,4 +103,13 @@ public interface AdminController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     );
+
+    @Operation(summary = "관리자 이메일 검색 API", description = """
+        - Description : 특정 이메일을 가진 관리자를 조회하는 API입니다.
+        - 요청 파라미터로 `email` 값을 전달하면 해당 이메일을 가진 관리자를 반환합니다.
+    """)
+    @ApiResponse(responseCode = "200", description = "관리자 조회 성공", content = @Content(schema = @Schema(implementation = AdminSearchResponse.class)))
+    @ApiResponse(responseCode = "404", description = "관리자를 찾을 수 없음")
+    @GetMapping("/search")
+    ResponseEntity<AdminSearchResponse> getAdminByEmail(@RequestParam String email);
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminControllerImpl.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminControllerImpl.java
@@ -7,6 +7,7 @@ import goorm.deepdive.team1.api.admin.presentation.request.AdminPasswordUpdateRe
 import goorm.deepdive.team1.api.admin.presentation.response.AdminListResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminRegisterResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminReissueResponse;
+import goorm.deepdive.team1.api.admin.presentation.response.AdminSearchResponse;
 import goorm.deepdive.team1.domain.admin.domain.Admin;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
@@ -91,5 +92,11 @@ public class AdminControllerImpl implements AdminController{
         Page<AdminListResponse> adminPage = adminFacade.getAdminsByPage(page, size)
                 .map(AdminListResponse::fromEntity);
         return ResponseEntity.ok(adminPage);
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<AdminSearchResponse> getAdminByEmail(@RequestParam String email) {
+        Admin admin = adminFacade.getAdminByEmail(email);
+        return ResponseEntity.ok(AdminSearchResponse.fromEntity(admin));
     }
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/response/AdminSearchResponse.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/response/AdminSearchResponse.java
@@ -1,0 +1,13 @@
+package goorm.deepdive.team1.api.admin.presentation.response;
+
+import goorm.deepdive.team1.domain.admin.domain.Admin;
+
+public record AdminSearchResponse(
+        Long id,
+        String email,
+        String role
+) {
+    public static AdminSearchResponse fromEntity(Admin admin) {
+        return new AdminSearchResponse(admin.getId(), admin.getEmail(), admin.getRole().name());
+    }
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/application/AdminQueryService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/application/AdminQueryService.java
@@ -2,6 +2,7 @@ package goorm.deepdive.team1.domain.admin.application;
 
 import goorm.deepdive.team1.domain.admin.domain.Admin;
 import goorm.deepdive.team1.domain.admin.infrastructure.AdminRepository;
+import goorm.deepdive.team1.domain.admin.exception.AdminNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -29,5 +30,10 @@ public class AdminQueryService {
     public Page<Admin> getAdminsByPage(int page, int size) {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "id"));
         return adminRepository.findAll(pageable);
+    }
+
+    public Admin getAdminByEmail(String email) {
+        return adminRepository.findByEmail(email)
+                .orElseThrow(AdminNotFoundException::new);
     }
 }


### PR DESCRIPTION
## Summary

>- close #44 

관리자 페이지에 필요한 이메일 검색에 따란 관리자  유저 응답 api 추가 

## Tasks

- 관리자 검색 api추가 /search 


## Screenshot

이메일 경우 중복이 없는 고유 값이기 때문에 응답은 하나만 응답하게 두었습니다 

없는 이메일 검색시 아래와 같이 표시됩니다 
<img width="1254" alt="스크린샷 2025-02-17 오후 3 34 41" src="https://github.com/user-attachments/assets/612f2360-4d48-445d-84de-9776fdad9eb3" />
<img width="1248" alt="스크린샷 2025-02-17 오후 3 34 29" src="https://github.com/user-attachments/assets/da8a5634-6c08-4a12-86ca-cb5937603021" />


