### PR TITLE
[#48] 유저 정보 수정 로직 수정

### DIFF
--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -9,6 +9,7 @@ import static goorm.deepdive.team1.domain.user.domain.enums.AgeGroups.TWENTIES;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -100,11 +101,18 @@ public class UserFacade {
 			request.regionAddress(), request.roadAddress()
 		);
 		User user = userQueryService.getById(id);
-		userCommandService.update(user, request.name(), request.email(), request.phoneNumber(), request.gender(), request.age(), address);
-		AddressHistory addressHistory = addressHistoryCommandService.create(user, address);
+
+		boolean isAddressChanged = !Objects.equals(address.getId(), user.getAddress().getId());
+
+		userCommandService.update(user, request.name(), request.email(), request.phoneNumber(),
+			request.gender(), request.age(), address);
+
+		if (isAddressChanged) {
+			AddressHistory addressHistory = addressHistoryCommandService.create(user, address);
+			addressHistoryProducer.sendMessageToDelete(addressHistory);
+		}
 
 		userProducer.sendMessageToUpdate(user);
-		addressHistoryProducer.sendMessageToDelete(addressHistory);
 	}
 
 	@Transactional


### PR DESCRIPTION
## Summary

>- close #48

**유저 정보 수정 로직 수정**

## Tasks

- 유저 정보 수정시 기존 조회랑 같은 지 검증 후 addresshistory 추가 여부 결정

## ScreenShot

수정 전
![스크린샷 2025-02-18 오전 9 20 27](https://github.com/user-attachments/assets/99f2647b-f2f8-4e66-a66e-5c4bf29c62cf)

수정 후
![스크린샷 2025-02-18 오전 9 33 39](https://github.com/user-attachments/assets/0da76051-8db6-49cb-882d-60001e427127)

