### PR TITLE
[#50] 관리자 role 변경 api 추가 

### DIFF
--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/application/AdminFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/application/AdminFacade.java
@@ -2,6 +2,7 @@ package goorm.deepdive.team1.api.admin.application;
 
 import goorm.deepdive.team1.api.admin.presentation.request.AdminRegisterRequest;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminPasswordUpdateRequest;
+import goorm.deepdive.team1.api.admin.presentation.request.AdminRoleUpdateRequest;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminRegisterResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminReissueResponse;
 import goorm.deepdive.team1.api.jwt.CookieUtil;
@@ -122,6 +123,10 @@ public class AdminFacade {
 
     public Admin getAdminByEmail(String email) {
         return adminQueryService.getAdminByEmail(email);
+    }
+
+    public void updateAdminRole(Long adminId, AdminRoleUpdateRequest request, Long loggedInAdminId) {
+        adminCommandService.updateAdminRole(adminId, request.role(), loggedInAdminId);
     }
 
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminController.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminController.java
@@ -1,6 +1,8 @@
 package goorm.deepdive.team1.api.admin.presentation;
 
+import goorm.deepdive.team1.api.admin.presentation.request.AdminRoleUpdateRequest;
 import goorm.deepdive.team1.api.admin.presentation.response.*;
+import goorm.deepdive.team1.api.security.CustomAdminDetails;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 
@@ -16,6 +18,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -112,4 +115,18 @@ public interface AdminController {
     @ApiResponse(responseCode = "404", description = "관리자를 찾을 수 없음")
     @GetMapping("/search")
     ResponseEntity<AdminSearchResponse> getAdminByEmail(@RequestParam String email);
+
+    @Operation(summary = "관리자 권한 변경 API", description = """
+        - Description : 특정 관리자의 권한을 변경하는 API입니다.
+        - 요청 파라미터로 `adminId`와 `새로운 Role` 값을 전달하면 해당 관리자의 권한이 업데이트됩니다.
+    """)
+    @ApiResponse(responseCode = "200", description = "권한 변경 성공")
+    @ApiResponse(responseCode = "403", description = "사용자 자신의 권한을 변경하려는 경우 403에러")
+    @ApiResponse(responseCode = "403", description = "role이 SUPER가 아닌 계정이 권한 변경하는 경우 403에러")
+    @ApiResponse(responseCode = "404", description = "관리자를 찾을 수 없음")
+    @PatchMapping("/{adminId}/role")
+    ResponseEntity<Void> updateAdminRole(
+            @PathVariable Long adminId,
+            @RequestBody AdminRoleUpdateRequest request,
+            @AuthenticationPrincipal CustomAdminDetails adminDetails);
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminControllerImpl.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/AdminControllerImpl.java
@@ -4,18 +4,19 @@ import goorm.deepdive.team1.api.admin.application.AdminFacade;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminLoginRequest;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminRegisterRequest;
 import goorm.deepdive.team1.api.admin.presentation.request.AdminPasswordUpdateRequest;
+import goorm.deepdive.team1.api.admin.presentation.request.AdminRoleUpdateRequest;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminListResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminRegisterResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminReissueResponse;
 import goorm.deepdive.team1.api.admin.presentation.response.AdminSearchResponse;
+import goorm.deepdive.team1.api.security.CustomAdminDetails;
 import goorm.deepdive.team1.domain.admin.domain.Admin;
-import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -98,5 +99,17 @@ public class AdminControllerImpl implements AdminController{
     public ResponseEntity<AdminSearchResponse> getAdminByEmail(@RequestParam String email) {
         Admin admin = adminFacade.getAdminByEmail(email);
         return ResponseEntity.ok(AdminSearchResponse.fromEntity(admin));
+    }
+
+    @PatchMapping("/{adminId}/role")
+    @PreAuthorize("hasAuthority('SUPER')")
+    public ResponseEntity<Void> updateAdminRole(
+            @PathVariable Long adminId,
+            @RequestBody AdminRoleUpdateRequest request,
+            @AuthenticationPrincipal CustomAdminDetails adminDetails // 현재 로그인한 관리자 정보
+    ) {
+
+        adminFacade.updateAdminRole(adminId, request,  adminDetails.getAdminId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/request/AdminRoleUpdateRequest.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/admin/presentation/request/AdminRoleUpdateRequest.java
@@ -1,0 +1,9 @@
+package goorm.deepdive.team1.api.admin.presentation.request;
+
+import goorm.deepdive.team1.domain.admin.domain.Role;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminRoleUpdateRequest(
+        @NotNull(message = "변경할 권한을 입력해주세요.") Role role
+) {
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/application/AdminCommandService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/application/AdminCommandService.java
@@ -2,6 +2,7 @@ package goorm.deepdive.team1.domain.admin.application;
 
 import goorm.deepdive.team1.domain.admin.domain.Admin;
 import goorm.deepdive.team1.domain.admin.domain.Role;
+import goorm.deepdive.team1.domain.admin.exception.CannotChangeOwnRoleException;
 import goorm.deepdive.team1.domain.admin.infrastructure.AdminRepository;
 import goorm.deepdive.team1.domain.admin.security.PasswordEncryptor;
 import goorm.deepdive.team1.domain.admin.exception.AdminPasswordMismatchException;
@@ -47,6 +48,20 @@ public class AdminCommandService {
 
         // 새 비밀번호 암호화 후 저장
         admin.updatePassword(passwordEncryptor.encode(newPassword));
+        adminRepository.save(admin);
+    }
+
+    @Transactional
+    public void updateAdminRole(Long adminId, Role newRole, Long loggedInAdminId) {
+
+        // 자기 자신의 Role 변경 방지
+        if (loggedInAdminId.equals(adminId)) {
+            throw new CannotChangeOwnRoleException();
+        }
+        Admin admin = adminRepository.findById(adminId)
+                .orElseThrow(AdminNotFoundException::new);
+
+        admin.updateRole(newRole);
         adminRepository.save(admin);
     }
 

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/domain/Admin.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/domain/Admin.java
@@ -37,5 +37,6 @@ public class Admin {
 	public void updatePassword(String password) {
 		this.password = password;
 	}
+	public void updateRole(Role role) { this.role = role;}
 
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/exception/AdminDomainExceptionCode.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/exception/AdminDomainExceptionCode.java
@@ -13,8 +13,8 @@ import static org.springframework.http.HttpStatus.*;
 public enum AdminDomainExceptionCode implements ExceptionCode {
 	PASSWORD_MISMATCH(UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 	ADMIN_NOT_FOUND(NOT_FOUND, "해당 이메일의 관리자를 찾을 수 없습니다."),
-	EMAIL_ALREADY_EXISTS(CONFLICT, "이미 존재하는 이메일입니다.");
-
+	EMAIL_ALREADY_EXISTS(CONFLICT, "이미 존재하는 이메일입니다."),
+	CANNOT_CHANGE_OWN_ROLE(FORBIDDEN, "자신의 역할(Role)은 변경할 수 없습니다.");
 	;
 
 	private final HttpStatus status;

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/exception/CannotChangeOwnRoleException.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/admin/exception/CannotChangeOwnRoleException.java
@@ -1,0 +1,11 @@
+package goorm.deepdive.team1.domain.admin.exception;
+
+import goorm.deepdive.team1.common.exception.CustomException;
+
+import static goorm.deepdive.team1.domain.admin.exception.AdminDomainExceptionCode.CANNOT_CHANGE_OWN_ROLE;
+
+public class CannotChangeOwnRoleException extends CustomException {
+    public CannotChangeOwnRoleException() {
+        super(CANNOT_CHANGE_OWN_ROLE);
+    }
+}


### PR DESCRIPTION
## Summary

>- close #50 
관리자 권한 변경 api 추가 


## Tasks

- 관리자 권한 변경 api 추가
-  스웨거 테스트

## To Reviewer

해당 api는 아래 조건이 있습니다
- 관리자는 자기 자신의 권한을 변경할수 없다 
- 권한이 normal인 계정은 권한 변경 api를 호출할수 없다 
- 존재 하지 않은 id로 해당 api를 요청할수 없다 


