### PR TITLE
[#71] 유저 Facade에서 AddressHistory 로직 분리

### DIFF
--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -29,13 +29,13 @@ import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.addresshistory.application.AddressHistoryCommandService;
 import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
 import goorm.deepdive.team1.domain.user.application.UserCommandService;
+import goorm.deepdive.team1.domain.user.application.UserProducer;
 import goorm.deepdive.team1.domain.user.application.UserQueryService;
 import goorm.deepdive.team1.domain.user.domain.User;
 import goorm.deepdive.team1.domain.user.domain.UserCache;
 import goorm.deepdive.team1.domain.user.domain.UserDocument;
 import goorm.deepdive.team1.domain.user.domain.enums.AgeGroups;
 import goorm.deepdive.team1.infra.kafka.producer.AddressHistoryProducer;
-import goorm.deepdive.team1.infra.kafka.producer.UserProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -9,7 +9,6 @@ import static goorm.deepdive.team1.domain.user.domain.enums.AgeGroups.TWENTIES;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -26,7 +25,6 @@ import goorm.deepdive.team1.domain.address.application.AddressCommandService;
 import goorm.deepdive.team1.domain.address.application.AddressQueryService;
 import goorm.deepdive.team1.domain.address.application.KakaoApiAddressService;
 import goorm.deepdive.team1.domain.address.domain.Address;
-import goorm.deepdive.team1.domain.addresshistory.application.AddressHistoryCommandService;
 import goorm.deepdive.team1.domain.user.application.UserCommandService;
 import goorm.deepdive.team1.domain.user.application.UserQueryService;
 import goorm.deepdive.team1.domain.user.domain.User;
@@ -42,7 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 public class UserFacade {
 	private final UserQueryService userQueryService;
 	private final UserCommandService userCommandService;
-	private final AddressHistoryCommandService addressHistoryCommandService;
 	private final AddressCommandService addressCommandService;
 	private final KakaoApiAddressService kakaoApiAddressService;
 	private final AddressQueryService addressQueryService;
@@ -59,8 +56,6 @@ public class UserFacade {
 			request.gender(),
 			request.age()
 		);
-
-		addressHistoryCommandService.create(user);
 
 		return UserPersistResponse.from(user);
 	}
@@ -97,10 +92,6 @@ public class UserFacade {
 		User user = userQueryService.getById(id);
 		userCommandService.update(user, request.name(), request.email(), request.phoneNumber(),
 			request.gender(), request.age(), address);
-
-		if (Objects.equals(address.getId(), user.getAddress().getId())) {
-			addressHistoryCommandService.update(user);
-		}
 	}
 
 	@Transactional
@@ -140,16 +131,15 @@ public class UserFacade {
 	}
 
 	@Transactional
-	@Scheduled(cron = "0 0 0 * * *")
+	@Scheduled(cron = "20 18 15 * * *")
 	public void cleanUpDeletedUsers() {
-		log.info("🗑️ 유저 삭제 스케줄링 작동...");
 		List<Long> userIdsToDelete = userQueryService.findIdsByDeletedAtIsNotNull();
 
 		if (userIdsToDelete.isEmpty()) {
 			log.info("✅ 삭제할 유저 데이터가 없습니다.");
 			return;
 		}
-		addressHistoryCommandService.cleanUpDeletedAddressHistories(userIdsToDelete);
+
 		userCommandService.cleanUpDeletedUsers(userIdsToDelete);
 	}
 

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -27,8 +27,6 @@ import goorm.deepdive.team1.domain.address.application.AddressQueryService;
 import goorm.deepdive.team1.domain.address.application.KakaoApiAddressService;
 import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.addresshistory.application.AddressHistoryCommandService;
-import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
-import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryProducer;
 import goorm.deepdive.team1.domain.user.application.UserCommandService;
 import goorm.deepdive.team1.domain.user.application.UserQueryService;
 import goorm.deepdive.team1.domain.user.domain.User;
@@ -46,7 +44,6 @@ public class UserFacade {
 	private final UserCommandService userCommandService;
 	private final AddressHistoryCommandService addressHistoryCommandService;
 	private final AddressCommandService addressCommandService;
-	private final AddressHistoryProducer addressHistoryProducer;
 	private final KakaoApiAddressService kakaoApiAddressService;
 	private final AddressQueryService addressQueryService;
 
@@ -63,9 +60,7 @@ public class UserFacade {
 			request.age()
 		);
 
-		AddressHistory addressHistory = addressHistoryCommandService.create(user, address);
-
-		addressHistoryProducer.sendMessageToCreate(addressHistory);
+		addressHistoryCommandService.create(user, address);
 
 		return UserPersistResponse.from(user);
 	}
@@ -108,8 +103,7 @@ public class UserFacade {
 			request.gender(), request.age(), address);
 
 		if (isAddressChanged) {
-			AddressHistory addressHistory = addressHistoryCommandService.create(user, address);
-			addressHistoryProducer.sendMessageToDelete(addressHistory);
+			addressHistoryCommandService.create(user, address);
 		}
 	}
 

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -35,7 +35,6 @@ import goorm.deepdive.team1.domain.user.domain.User;
 import goorm.deepdive.team1.domain.user.domain.UserCache;
 import goorm.deepdive.team1.domain.user.domain.UserDocument;
 import goorm.deepdive.team1.domain.user.domain.enums.AgeGroups;
-import goorm.deepdive.team1.domain.user.infrastructure.UserProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -47,7 +46,6 @@ public class UserFacade {
 	private final UserCommandService userCommandService;
 	private final AddressHistoryCommandService addressHistoryCommandService;
 	private final AddressCommandService addressCommandService;
-	private final UserProducer userProducer;
 	private final AddressHistoryProducer addressHistoryProducer;
 	private final KakaoApiAddressService kakaoApiAddressService;
 	private final AddressQueryService addressQueryService;
@@ -67,7 +65,6 @@ public class UserFacade {
 
 		AddressHistory addressHistory = addressHistoryCommandService.create(user, address);
 
-		userProducer.sendMessageToCreate(user);
 		addressHistoryProducer.sendMessageToCreate(addressHistory);
 
 		return UserPersistResponse.from(user);
@@ -114,8 +111,6 @@ public class UserFacade {
 			AddressHistory addressHistory = addressHistoryCommandService.create(user, address);
 			addressHistoryProducer.sendMessageToDelete(addressHistory);
 		}
-
-		userProducer.sendMessageToUpdate(user);
 	}
 
 	@Transactional

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -60,7 +60,7 @@ public class UserFacade {
 			request.age()
 		);
 
-		addressHistoryCommandService.create(user, address);
+		addressHistoryCommandService.create(user);
 
 		return UserPersistResponse.from(user);
 	}
@@ -99,7 +99,7 @@ public class UserFacade {
 			request.gender(), request.age(), address);
 
 		if (Objects.equals(address.getId(), user.getAddress().getId())) {
-			addressHistoryCommandService.create(user, address);
+			addressHistoryCommandService.update(user);
 		}
 	}
 

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -94,15 +94,11 @@ public class UserFacade {
 	@Transactional
 	public void update(Long id, UserUpdateRequest request) {
 		Address address = findOrCreateAddress(request.roadAddress());
-
 		User user = userQueryService.getById(id);
-
-		boolean isAddressChanged = !Objects.equals(address.getId(), user.getAddress().getId());
-
 		userCommandService.update(user, request.name(), request.email(), request.phoneNumber(),
 			request.gender(), request.age(), address);
 
-		if (isAddressChanged) {
+		if (Objects.equals(address.getId(), user.getAddress().getId())) {
 			addressHistoryCommandService.create(user, address);
 		}
 	}

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/application/UserFacade.java
@@ -28,14 +28,14 @@ import goorm.deepdive.team1.domain.address.application.KakaoApiAddressService;
 import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.addresshistory.application.AddressHistoryCommandService;
 import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryProducer;
 import goorm.deepdive.team1.domain.user.application.UserCommandService;
-import goorm.deepdive.team1.domain.user.application.UserProducer;
 import goorm.deepdive.team1.domain.user.application.UserQueryService;
 import goorm.deepdive.team1.domain.user.domain.User;
 import goorm.deepdive.team1.domain.user.domain.UserCache;
 import goorm.deepdive.team1.domain.user.domain.UserDocument;
 import goorm.deepdive.team1.domain.user.domain.enums.AgeGroups;
-import goorm.deepdive.team1.infra.kafka.producer.AddressHistoryProducer;
+import goorm.deepdive.team1.domain.user.infrastructure.UserProducer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/listener/UserEventListener.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/listener/UserEventListener.java
@@ -1,0 +1,21 @@
+package goorm.deepdive.team1.api.user.listener;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import goorm.deepdive.team1.domain.addresshistory.application.AddressHistoryCommandService;
+import goorm.deepdive.team1.domain.user.domain.User;
+import goorm.deepdive.team1.domain.user.event.UserCreatedEvent;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class UserEventListener {
+	private final AddressHistoryCommandService addressHistoryCommandService;
+
+	@EventListener
+	public void handleUserCreatedEvent(UserCreatedEvent event) {
+		User user = event.user();
+		addressHistoryCommandService.create(user);
+	}
+}

--- a/team1-api/src/main/java/goorm/deepdive/team1/api/user/listener/UserEventListener.java
+++ b/team1-api/src/main/java/goorm/deepdive/team1/api/user/listener/UserEventListener.java
@@ -4,8 +4,9 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import goorm.deepdive.team1.domain.addresshistory.application.AddressHistoryCommandService;
-import goorm.deepdive.team1.domain.user.domain.User;
 import goorm.deepdive.team1.domain.user.event.UserCreatedEvent;
+import goorm.deepdive.team1.domain.user.event.UserDeletedEvent;
+import goorm.deepdive.team1.domain.user.event.UserUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -15,7 +16,16 @@ public class UserEventListener {
 
 	@EventListener
 	public void handleUserCreatedEvent(UserCreatedEvent event) {
-		User user = event.user();
-		addressHistoryCommandService.create(user);
+		addressHistoryCommandService.create(event.user());
+	}
+
+	@EventListener
+	public void handleUserUpdatedEvent(UserUpdatedEvent event) {
+		addressHistoryCommandService.update(event.user());
+	}
+
+	@EventListener
+	public void handleUserDeletedEvent(UserDeletedEvent event) {
+		addressHistoryCommandService.cleanUpDeletedAddressHistories(event.userIds());
 	}
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/application/AddressHistoryCommandService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/application/AddressHistoryCommandService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryProducer;
 import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryRepository;
 import goorm.deepdive.team1.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +17,16 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 public class AddressHistoryCommandService {
 	private final AddressHistoryRepository addressHistoryRepository;
+	private final AddressHistoryProducer addressHistoryProducer;
 
-	public AddressHistory create(User user, Address address) {
+	public void create(User user, Address address) {
 		AddressHistory addressHistory = AddressHistory.create(user, address);
-		return addressHistoryRepository.save(addressHistory);
+		addressHistoryProducer.sendMessageToCreate(addressHistoryRepository.save(addressHistory));
+	}
+
+	public void update(User user, Address address) {
+		AddressHistory addressHistory = AddressHistory.create(user, address);
+		addressHistoryProducer.sendMessageToCreate(addressHistoryRepository.save(addressHistory));
 	}
 
 	public void saveAll(List<AddressHistory> addressHistories) {

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/application/AddressHistoryCommandService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/application/AddressHistoryCommandService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
 import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryProducer;
 import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryRepository;
@@ -19,14 +18,14 @@ public class AddressHistoryCommandService {
 	private final AddressHistoryRepository addressHistoryRepository;
 	private final AddressHistoryProducer addressHistoryProducer;
 
-	public void create(User user, Address address) {
-		AddressHistory addressHistory = AddressHistory.create(user, address);
+	public void create(User user) {
+		AddressHistory addressHistory = AddressHistory.create(user);
 		addressHistoryProducer.sendMessageToCreate(addressHistoryRepository.save(addressHistory));
 	}
 
-	public void update(User user, Address address) {
-		AddressHistory addressHistory = AddressHistory.create(user, address);
-		addressHistoryProducer.sendMessageToCreate(addressHistoryRepository.save(addressHistory));
+	public void update(User user) {
+		AddressHistory addressHistory = AddressHistory.create(user);
+		addressHistoryProducer.sendMessageToDelete(addressHistoryRepository.save(addressHistory));
 	}
 
 	public void saveAll(List<AddressHistory> addressHistories) {

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/domain/AddressHistory.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/domain/AddressHistory.java
@@ -7,6 +7,7 @@ import static lombok.AccessLevel.PROTECTED;
 import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.common.BaseTimeEntity;
 import goorm.deepdive.team1.domain.user.domain.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -32,7 +33,7 @@ public class AddressHistory extends BaseTimeEntity {
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
 
-	@ManyToOne(fetch = LAZY)
+	@ManyToOne(fetch = LAZY, cascade = CascadeType.ALL)
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/domain/AddressHistory.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/domain/AddressHistory.java
@@ -40,10 +40,10 @@ public class AddressHistory extends BaseTimeEntity {
 	@JoinColumn(name = "address_id", nullable = false)
 	private Address address;
 
-	public static AddressHistory create(User user, Address address) {
+	public static AddressHistory create(User user) {
 		return AddressHistory.builder()
 			.user(user)
-			.address(address)
+			.address(user.getAddress())
 			.build();
 	}
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/infrastructure/AddressHistoryProducer.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/addresshistory/infrastructure/AddressHistoryProducer.java
@@ -1,0 +1,9 @@
+package goorm.deepdive.team1.domain.addresshistory.infrastructure;
+
+import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+
+public interface AddressHistoryProducer {
+	void sendMessageToCreate(AddressHistory addressHistory);
+
+	void sendMessageToDelete(AddressHistory addressHistory);
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/application/UserCommandService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/application/UserCommandService.java
@@ -1,13 +1,17 @@
 package goorm.deepdive.team1.domain.user.application;
 
 import java.util.List;
+import java.util.Objects;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.user.domain.User;
 import goorm.deepdive.team1.domain.user.domain.UserCache;
 import goorm.deepdive.team1.domain.user.domain.enums.Gender;
+import goorm.deepdive.team1.domain.user.event.UserCreatedEvent;
+import goorm.deepdive.team1.domain.user.event.UserUpdatedEvent;
 import goorm.deepdive.team1.domain.user.infrastructure.UserProducer;
 import goorm.deepdive.team1.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -18,11 +22,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UserCommandService {
 	private final UserRepository userRepository;
+	private final ApplicationEventPublisher eventPublisher;
 	private final UserProducer userProducer;
 
 	public User create(String name, String email, String phoneNumber, Address address, Gender gender, Integer age) {
 		User user = User.create(name, email, phoneNumber, address, gender, age);
 		userProducer.sendMessageToCreate(userRepository.save(user));
+		eventPublisher.publishEvent(UserCreatedEvent.of(user));
 		return user;
 	}
 
@@ -32,9 +38,16 @@ public class UserCommandService {
 		user.updatePhoneNumber(phoneNumber);
 		user.updateGender(gender);
 		user.updateAge(age);
-		user.updateAddress(address);
 
+		if (!Objects.equals(user.getAddress().getId(), address.getId())) {
+			updateAddress(user, address);
+		}
+	}
+
+	private void updateAddress(User user, Address address) {
+		user.updateAddress(address);
 		userProducer.sendMessageToUpdate(user);
+		eventPublisher.publishEvent(UserUpdatedEvent.of(user));
 	}
 
 	public void delete(User user) {
@@ -48,6 +61,7 @@ public class UserCommandService {
 	public void cleanUpDeletedUsers(List<Long> ids) {
 		userRepository.deleteScheduling(ids);
 		log.info("✅ {}명의 유저 데이터가 삭제 되었습니다", ids.size());
+		eventPublisher.publishEvent(ids);
 	}
 
 	public void saveAllCaches(List<UserCache> userCaches) {

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/application/UserCommandService.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/application/UserCommandService.java
@@ -8,6 +8,7 @@ import goorm.deepdive.team1.domain.address.domain.Address;
 import goorm.deepdive.team1.domain.user.domain.User;
 import goorm.deepdive.team1.domain.user.domain.UserCache;
 import goorm.deepdive.team1.domain.user.domain.enums.Gender;
+import goorm.deepdive.team1.domain.user.infrastructure.UserProducer;
 import goorm.deepdive.team1.domain.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,10 +18,12 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UserCommandService {
 	private final UserRepository userRepository;
+	private final UserProducer userProducer;
 
 	public User create(String name, String email, String phoneNumber, Address address, Gender gender, Integer age) {
 		User user = User.create(name, email, phoneNumber, address, gender, age);
-		return userRepository.save(user);
+		userProducer.sendMessageToCreate(userRepository.save(user));
+		return user;
 	}
 
 	public void update(User user, String name, String email, String phoneNumber, Gender gender, Integer age, Address address) {
@@ -30,6 +33,8 @@ public class UserCommandService {
 		user.updateGender(gender);
 		user.updateAge(age);
 		user.updateAddress(address);
+
+		userProducer.sendMessageToUpdate(user);
 	}
 
 	public void delete(User user) {

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/application/UserProducer.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/application/UserProducer.java
@@ -1,0 +1,9 @@
+package goorm.deepdive.team1.domain.user.application;
+
+import goorm.deepdive.team1.domain.user.domain.User;
+
+public interface UserProducer {
+	void sendMessageToCreate(User user);
+
+	void sendMessageToUpdate(User user);
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserCreatedEvent.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserCreatedEvent.java
@@ -1,0 +1,8 @@
+package goorm.deepdive.team1.domain.user.event;
+
+import goorm.deepdive.team1.domain.user.domain.User;
+
+public record UserCreatedEvent(
+	User user
+) {
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserCreatedEvent.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserCreatedEvent.java
@@ -1,8 +1,15 @@
 package goorm.deepdive.team1.domain.user.event;
 
 import goorm.deepdive.team1.domain.user.domain.User;
+import lombok.Builder;
 
+@Builder
 public record UserCreatedEvent(
 	User user
 ) {
+	public static UserCreatedEvent of(User user) {
+		return UserCreatedEvent.builder()
+			.user(user)
+			.build();
+	}
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserDeletedEvent.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserDeletedEvent.java
@@ -1,0 +1,16 @@
+package goorm.deepdive.team1.domain.user.event;
+
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record UserDeletedEvent(
+	List<Long> userIds
+) {
+	public static UserDeletedEvent of(List<Long> userIds) {
+		return UserDeletedEvent.builder()
+			.userIds(userIds)
+			.build();
+	}
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserUpdatedEvent.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserUpdatedEvent.java
@@ -1,8 +1,15 @@
 package goorm.deepdive.team1.domain.user.event;
 
 import goorm.deepdive.team1.domain.user.domain.User;
+import lombok.Builder;
 
+@Builder
 public record UserUpdatedEvent(
 	User user
 ) {
+	public static UserUpdatedEvent of(User user) {
+		return UserUpdatedEvent.builder()
+			.user(user)
+			.build();
+	}
 }

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserUpdatedEvent.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/event/UserUpdatedEvent.java
@@ -1,0 +1,8 @@
+package goorm.deepdive.team1.domain.user.event;
+
+import goorm.deepdive.team1.domain.user.domain.User;
+
+public record UserUpdatedEvent(
+	User user
+) {
+}

--- a/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/infrastructure/UserProducer.java
+++ b/team1-domain/src/main/java/goorm/deepdive/team1/domain/user/infrastructure/UserProducer.java
@@ -1,4 +1,4 @@
-package goorm.deepdive.team1.domain.user.application;
+package goorm.deepdive.team1.domain.user.infrastructure;
 
 import goorm.deepdive.team1.domain.user.domain.User;
 

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/kafka/consumer/KafkaUserConsumer.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/kafka/consumer/KafkaUserConsumer.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class UserConsumer {
+public class KafkaUserConsumer {
 	private final RedisUserRepository redisUserRepository;
 	private final ElasticUserRepository elasticUserRepository;
 	private final ObjectMapper objectMapper;

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/kafka/producer/KafkaAddressHistoryProducer.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/kafka/producer/KafkaAddressHistoryProducer.java
@@ -7,17 +7,19 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import goorm.deepdive.team1.domain.addresshistory.domain.AddressHistory;
+import goorm.deepdive.team1.domain.addresshistory.infrastructure.AddressHistoryProducer;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class AddressHistoryProducer {
+public class KafkaAddressHistoryProducer implements AddressHistoryProducer {
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 	private final ObjectMapper objectMapper;
 
 	private static final String CREATE_ADDRESS_HISTORY = "create-address-history";
 	private static final String DELETE_ADDRESS_HISTORY = "delete-address-history";
 
+	@Override
 	public void sendMessageToCreate(AddressHistory addressHistory) {
 		try {
 			String addressHistoryJson = objectMapper.writeValueAsString(addressHistory);
@@ -27,6 +29,7 @@ public class AddressHistoryProducer {
 		}
 	}
 
+	@Override
 	public void sendMessageToDelete(AddressHistory addressHistory) {
 		try {
 			String addressHistoryJson = objectMapper.writeValueAsString(addressHistory);

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/kafka/producer/KafkaUserProducer.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/kafka/producer/KafkaUserProducer.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import goorm.deepdive.team1.domain.user.application.UserProducer;
+import goorm.deepdive.team1.domain.user.infrastructure.UserProducer;
 import goorm.deepdive.team1.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 

--- a/team1-infra/src/main/java/goorm/deepdive/team1/infra/kafka/producer/KafkaUserProducer.java
+++ b/team1-infra/src/main/java/goorm/deepdive/team1/infra/kafka/producer/KafkaUserProducer.java
@@ -6,18 +6,20 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import goorm.deepdive.team1.domain.user.application.UserProducer;
 import goorm.deepdive.team1.domain.user.domain.User;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class UserProducer {
+public class KafkaUserProducer implements UserProducer {
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 	private final ObjectMapper objectMapper;
 
 	private static final String CREATE_USER = "create-user";
 	private static final String UPDATE_USER = "update-user";
 
+	@Override
 	public void sendMessageToCreate(User user) {
 		try {
 			String userJson = objectMapper.writeValueAsString(user);
@@ -27,6 +29,7 @@ public class UserProducer {
 		}
 	}
 
+	@Override
 	public void sendMessageToUpdate(User user) {
 		try {
 			String userJson = objectMapper.writeValueAsString(user);


### PR DESCRIPTION
## Summary

>- close #71 

**유저 Facade에서 AddressHistory 로직 분리**

## Tasks

- User event 관련 객체 생성
- UserFacade에 있는 AddressHistory 관련 내용 이벤트 처리